### PR TITLE
Fix Expected Output on Types with Enum Attributes

### DIFF
--- a/go/maven.apache.org/fml-1.0.1.xsd.go
+++ b/go/maven.apache.org/fml-1.0.1.xsd.go
@@ -474,7 +474,7 @@ type Script struct {
 	TypeAttr     string      `xml:"type,attr"`
 	LanguageAttr interface{} `xml:"language,attr,omitempty"`
 	SrcAttr      string      `xml:"src,attr,omitempty"`
-	DeferAttr    interface{} `xml:"defer,attr,omitempty"`
+	DeferAttr    string      `xml:"defer,attr,omitempty"`
 	XmlSpaceAttr *Space      `xml:"xml:space,attr,omitempty"`
 }
 
@@ -488,16 +488,16 @@ type Noscript struct {
 type Iframe struct {
 	XMLName          xml.Name `xml:"iframe"`
 	Coreattrs        *Coreattrs
-	LongdescAttr     string      `xml:"longdesc,attr,omitempty"`
-	NameAttr         string      `xml:"name,attr,omitempty"`
-	SrcAttr          string      `xml:"src,attr,omitempty"`
-	FrameborderAttr  interface{} `xml:"frameborder,attr,omitempty"`
-	MarginwidthAttr  int         `xml:"marginwidth,attr,omitempty"`
-	MarginheightAttr int         `xml:"marginheight,attr,omitempty"`
-	ScrollingAttr    interface{} `xml:"scrolling,attr,omitempty"`
-	AlignAttr        string      `xml:"align,attr,omitempty"`
-	HeightAttr       string      `xml:"height,attr,omitempty"`
-	WidthAttr        string      `xml:"width,attr,omitempty"`
+	LongdescAttr     string `xml:"longdesc,attr,omitempty"`
+	NameAttr         string `xml:"name,attr,omitempty"`
+	SrcAttr          string `xml:"src,attr,omitempty"`
+	FrameborderAttr  string `xml:"frameborder,attr,omitempty"`
+	MarginwidthAttr  int    `xml:"marginwidth,attr,omitempty"`
+	MarginheightAttr int    `xml:"marginheight,attr,omitempty"`
+	ScrollingAttr    string `xml:"scrolling,attr,omitempty"`
+	AlignAttr        string `xml:"align,attr,omitempty"`
+	HeightAttr       string `xml:"height,attr,omitempty"`
+	WidthAttr        string `xml:"width,attr,omitempty"`
 }
 
 // Noframes ...
@@ -569,9 +569,9 @@ type ULStyle string
 type Ul struct {
 	XMLName     xml.Name `xml:"ul"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Ul          string      `xml:"ul"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Ul          string `xml:"ul"`
 }
 
 // OLStyle is Ordered list numbering style
@@ -590,26 +590,26 @@ type OLStyle string
 type Ol struct {
 	XMLName     xml.Name `xml:"ol"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	StartAttr   int         `xml:"start,attr,omitempty"`
-	Ol          string      `xml:"ol"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	StartAttr   int    `xml:"start,attr,omitempty"`
+	Ol          string `xml:"ol"`
 }
 
 // Menu ...
 type Menu struct {
 	XMLName     xml.Name `xml:"menu"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Menu        string      `xml:"menu"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Menu        string `xml:"menu"`
 }
 
 // Dir ...
 type Dir struct {
 	XMLName     xml.Name `xml:"dir"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dir         string      `xml:"dir"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dir         string `xml:"dir"`
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
@@ -627,9 +627,9 @@ type Li struct {
 type Dl struct {
 	XMLName     xml.Name `xml:"dl"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dt          *Dt         `xml:"dt"`
-	Dl          string      `xml:"dl"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dt          *Dt    `xml:"dt"`
+	Dl          string `xml:"dl"`
 }
 
 // Dt ...
@@ -657,10 +657,10 @@ type Address struct {
 type Hr struct {
 	XMLName     xml.Name `xml:"hr"`
 	Attrs       *Attrs
-	AlignAttr   interface{} `xml:"align,attr,omitempty"`
-	NoshadeAttr interface{} `xml:"noshade,attr,omitempty"`
-	SizeAttr    int         `xml:"size,attr,omitempty"`
-	WidthAttr   string      `xml:"width,attr,omitempty"`
+	AlignAttr   string `xml:"align,attr,omitempty"`
+	NoshadeAttr string `xml:"noshade,attr,omitempty"`
+	SizeAttr    int    `xml:"size,attr,omitempty"`
+	WidthAttr   string `xml:"width,attr,omitempty"`
 }
 
 // Pre ...
@@ -728,16 +728,16 @@ type Bdo struct {
 	XMLName     xml.Name `xml:"bdo"`
 	Coreattrs   *Coreattrs
 	Events      *Events
-	LangAttr    string      `xml:"lang,attr,omitempty"`
-	XmlLangAttr *Lang       `xml:"xml:lang,attr,omitempty"`
-	DirAttr     interface{} `xml:"dir,attr"`
+	LangAttr    string `xml:"lang,attr,omitempty"`
+	XmlLangAttr *Lang  `xml:"xml:lang,attr,omitempty"`
+	DirAttr     string `xml:"dir,attr"`
 }
 
 // Br ...
 type Br struct {
 	XMLName   xml.Name `xml:"br"`
 	Coreattrs *Coreattrs
-	ClearAttr interface{} `xml:"clear,attr,omitempty"`
+	ClearAttr string `xml:"clear,attr,omitempty"`
 }
 
 // Em ...
@@ -890,23 +890,23 @@ type Font struct {
 type Object struct {
 	XMLName      xml.Name `xml:"object"`
 	Attrs        *Attrs
-	DeclareAttr  interface{} `xml:"declare,attr,omitempty"`
-	ClassidAttr  string      `xml:"classid,attr,omitempty"`
-	CodebaseAttr string      `xml:"codebase,attr,omitempty"`
-	DataAttr     string      `xml:"data,attr,omitempty"`
-	TypeAttr     string      `xml:"type,attr,omitempty"`
-	CodetypeAttr string      `xml:"codetype,attr,omitempty"`
-	ArchiveAttr  string      `xml:"archive,attr,omitempty"`
-	StandbyAttr  string      `xml:"standby,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   int         `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	DeclareAttr  string `xml:"declare,attr,omitempty"`
+	ClassidAttr  string `xml:"classid,attr,omitempty"`
+	CodebaseAttr string `xml:"codebase,attr,omitempty"`
+	DataAttr     string `xml:"data,attr,omitempty"`
+	TypeAttr     string `xml:"type,attr,omitempty"`
+	CodetypeAttr string `xml:"codetype,attr,omitempty"`
+	ArchiveAttr  string `xml:"archive,attr,omitempty"`
+	StandbyAttr  string `xml:"standby,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	TabindexAttr int    `xml:"tabindex,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   int    `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 	Block        *Block
 	Inline       *Inline
 	Misc         *Misc
@@ -920,7 +920,7 @@ type Param struct {
 	IdAttr        string      `xml:"id,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	ValuetypeAttr interface{} `xml:"valuetype,attr,omitempty"`
+	ValuetypeAttr string      `xml:"valuetype,attr,omitempty"`
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 }
 
@@ -950,18 +950,18 @@ type Applet struct {
 type Img struct {
 	XMLName      xml.Name `xml:"img"`
 	Attrs        *Attrs
-	SrcAttr      string      `xml:"src,attr"`
-	AltAttr      string      `xml:"alt,attr"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	LongdescAttr string      `xml:"longdesc,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	IsmapAttr    interface{} `xml:"ismap,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   string      `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	SrcAttr      string `xml:"src,attr"`
+	AltAttr      string `xml:"alt,attr"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	LongdescAttr string `xml:"longdesc,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	IsmapAttr    string `xml:"ismap,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   string `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 }
 
 // Map ...
@@ -985,26 +985,26 @@ type Area struct {
 	XMLName    xml.Name `xml:"area"`
 	Attrs      *Attrs
 	Focus      *Focus
-	ShapeAttr  string      `xml:"shape,attr,omitempty"`
-	CoordsAttr string      `xml:"coords,attr,omitempty"`
-	HrefAttr   string      `xml:"href,attr,omitempty"`
-	NohrefAttr interface{} `xml:"nohref,attr,omitempty"`
-	AltAttr    string      `xml:"alt,attr"`
-	TargetAttr string      `xml:"target,attr,omitempty"`
+	ShapeAttr  string `xml:"shape,attr,omitempty"`
+	CoordsAttr string `xml:"coords,attr,omitempty"`
+	HrefAttr   string `xml:"href,attr,omitempty"`
+	NohrefAttr string `xml:"nohref,attr,omitempty"`
+	AltAttr    string `xml:"alt,attr"`
+	TargetAttr string `xml:"target,attr,omitempty"`
 }
 
 // Form ...
 type Form struct {
 	XMLName           xml.Name `xml:"form"`
 	Attrs             *Attrs
-	ActionAttr        string      `xml:"action,attr"`
-	MethodAttr        interface{} `xml:"method,attr,omitempty"`
-	EnctypeAttr       string      `xml:"enctype,attr,omitempty"`
-	OnsubmitAttr      string      `xml:"onsubmit,attr,omitempty"`
-	OnresetAttr       string      `xml:"onreset,attr,omitempty"`
-	AcceptAttr        string      `xml:"accept,attr,omitempty"`
-	AcceptcharsetAttr string      `xml:"accept-charset,attr,omitempty"`
-	TargetAttr        string      `xml:"target,attr,omitempty"`
+	ActionAttr        string `xml:"action,attr"`
+	MethodAttr        string `xml:"method,attr,omitempty"`
+	EnctypeAttr       string `xml:"enctype,attr,omitempty"`
+	OnsubmitAttr      string `xml:"onsubmit,attr,omitempty"`
+	OnresetAttr       string `xml:"onreset,attr,omitempty"`
+	AcceptAttr        string `xml:"accept,attr,omitempty"`
+	AcceptcharsetAttr string `xml:"accept-charset,attr,omitempty"`
+	TargetAttr        string `xml:"target,attr,omitempty"`
 }
 
 // Label ...
@@ -1028,9 +1028,9 @@ type Input struct {
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr,omitempty"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	CheckedAttr   interface{} `xml:"checked,attr,omitempty"`
-	DisabledAttr  interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr  interface{} `xml:"readonly,attr,omitempty"`
+	CheckedAttr   string      `xml:"checked,attr,omitempty"`
+	DisabledAttr  string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr  string      `xml:"readonly,attr,omitempty"`
 	SizeAttr      interface{} `xml:"size,attr,omitempty"`
 	MaxlengthAttr int         `xml:"maxlength,attr,omitempty"`
 	SrcAttr       string      `xml:"src,attr,omitempty"`
@@ -1048,8 +1048,8 @@ type Select struct {
 	Attrs        *Attrs
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	SizeAttr     int         `xml:"size,attr,omitempty"`
-	MultipleAttr interface{} `xml:"multiple,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	MultipleAttr string      `xml:"multiple,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
 	OnfocusAttr  string      `xml:"onfocus,attr,omitempty"`
 	OnblurAttr   string      `xml:"onblur,attr,omitempty"`
@@ -1062,17 +1062,17 @@ type Select struct {
 type Optgroup struct {
 	XMLName      xml.Name `xml:"optgroup"`
 	Attrs        *Attrs
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	LabelAttr    string      `xml:"label,attr"`
-	Optgroup     string      `xml:"optgroup"`
+	DisabledAttr string `xml:"disabled,attr,omitempty"`
+	LabelAttr    string `xml:"label,attr"`
+	Optgroup     string `xml:"optgroup"`
 }
 
 // Option ...
 type Option struct {
 	XMLName      xml.Name `xml:"option"`
 	Attrs        *Attrs
-	SelectedAttr interface{} `xml:"selected,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	SelectedAttr string      `xml:"selected,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	LabelAttr    string      `xml:"label,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
 }
@@ -1085,8 +1085,8 @@ type Textarea struct {
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	RowsAttr     int         `xml:"rows,attr"`
 	ColsAttr     int         `xml:"cols,attr"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr interface{} `xml:"readonly,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr string      `xml:"readonly,attr,omitempty"`
 	OnselectAttr string      `xml:"onselect,attr,omitempty"`
 	OnchangeAttr string      `xml:"onchange,attr,omitempty"`
 }
@@ -1120,8 +1120,8 @@ type Button struct {
 	Focus        *Focus
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
-	TypeAttr     interface{} `xml:"type,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	TypeAttr     string      `xml:"type,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 }
 
 // Isindex ...
@@ -1272,7 +1272,7 @@ type Th struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`
@@ -1290,7 +1290,7 @@ type Td struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`

--- a/go/maven.apache.org/fml-1.0.xsd.go
+++ b/go/maven.apache.org/fml-1.0.xsd.go
@@ -473,7 +473,7 @@ type Script struct {
 	TypeAttr     string      `xml:"type,attr"`
 	LanguageAttr interface{} `xml:"language,attr,omitempty"`
 	SrcAttr      string      `xml:"src,attr,omitempty"`
-	DeferAttr    interface{} `xml:"defer,attr,omitempty"`
+	DeferAttr    string      `xml:"defer,attr,omitempty"`
 	XmlSpaceAttr *Space      `xml:"xml:space,attr,omitempty"`
 }
 
@@ -487,16 +487,16 @@ type Noscript struct {
 type Iframe struct {
 	XMLName          xml.Name `xml:"iframe"`
 	Coreattrs        *Coreattrs
-	LongdescAttr     string      `xml:"longdesc,attr,omitempty"`
-	NameAttr         string      `xml:"name,attr,omitempty"`
-	SrcAttr          string      `xml:"src,attr,omitempty"`
-	FrameborderAttr  interface{} `xml:"frameborder,attr,omitempty"`
-	MarginwidthAttr  int         `xml:"marginwidth,attr,omitempty"`
-	MarginheightAttr int         `xml:"marginheight,attr,omitempty"`
-	ScrollingAttr    interface{} `xml:"scrolling,attr,omitempty"`
-	AlignAttr        string      `xml:"align,attr,omitempty"`
-	HeightAttr       string      `xml:"height,attr,omitempty"`
-	WidthAttr        string      `xml:"width,attr,omitempty"`
+	LongdescAttr     string `xml:"longdesc,attr,omitempty"`
+	NameAttr         string `xml:"name,attr,omitempty"`
+	SrcAttr          string `xml:"src,attr,omitempty"`
+	FrameborderAttr  string `xml:"frameborder,attr,omitempty"`
+	MarginwidthAttr  int    `xml:"marginwidth,attr,omitempty"`
+	MarginheightAttr int    `xml:"marginheight,attr,omitempty"`
+	ScrollingAttr    string `xml:"scrolling,attr,omitempty"`
+	AlignAttr        string `xml:"align,attr,omitempty"`
+	HeightAttr       string `xml:"height,attr,omitempty"`
+	WidthAttr        string `xml:"width,attr,omitempty"`
 }
 
 // Noframes ...
@@ -568,9 +568,9 @@ type ULStyle string
 type Ul struct {
 	XMLName     xml.Name `xml:"ul"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Ul          string      `xml:"ul"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Ul          string `xml:"ul"`
 }
 
 // OLStyle is Ordered list numbering style
@@ -589,26 +589,26 @@ type OLStyle string
 type Ol struct {
 	XMLName     xml.Name `xml:"ol"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	StartAttr   int         `xml:"start,attr,omitempty"`
-	Ol          string      `xml:"ol"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	StartAttr   int    `xml:"start,attr,omitempty"`
+	Ol          string `xml:"ol"`
 }
 
 // Menu ...
 type Menu struct {
 	XMLName     xml.Name `xml:"menu"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Menu        string      `xml:"menu"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Menu        string `xml:"menu"`
 }
 
 // Dir ...
 type Dir struct {
 	XMLName     xml.Name `xml:"dir"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dir         string      `xml:"dir"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dir         string `xml:"dir"`
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
@@ -626,9 +626,9 @@ type Li struct {
 type Dl struct {
 	XMLName     xml.Name `xml:"dl"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dt          *Dt         `xml:"dt"`
-	Dl          string      `xml:"dl"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dt          *Dt    `xml:"dt"`
+	Dl          string `xml:"dl"`
 }
 
 // Dt ...
@@ -656,10 +656,10 @@ type Address struct {
 type Hr struct {
 	XMLName     xml.Name `xml:"hr"`
 	Attrs       *Attrs
-	AlignAttr   interface{} `xml:"align,attr,omitempty"`
-	NoshadeAttr interface{} `xml:"noshade,attr,omitempty"`
-	SizeAttr    int         `xml:"size,attr,omitempty"`
-	WidthAttr   string      `xml:"width,attr,omitempty"`
+	AlignAttr   string `xml:"align,attr,omitempty"`
+	NoshadeAttr string `xml:"noshade,attr,omitempty"`
+	SizeAttr    int    `xml:"size,attr,omitempty"`
+	WidthAttr   string `xml:"width,attr,omitempty"`
 }
 
 // Pre ...
@@ -727,16 +727,16 @@ type Bdo struct {
 	XMLName     xml.Name `xml:"bdo"`
 	Coreattrs   *Coreattrs
 	Events      *Events
-	LangAttr    string      `xml:"lang,attr,omitempty"`
-	XmlLangAttr *Lang       `xml:"xml:lang,attr,omitempty"`
-	DirAttr     interface{} `xml:"dir,attr"`
+	LangAttr    string `xml:"lang,attr,omitempty"`
+	XmlLangAttr *Lang  `xml:"xml:lang,attr,omitempty"`
+	DirAttr     string `xml:"dir,attr"`
 }
 
 // Br ...
 type Br struct {
 	XMLName   xml.Name `xml:"br"`
 	Coreattrs *Coreattrs
-	ClearAttr interface{} `xml:"clear,attr,omitempty"`
+	ClearAttr string `xml:"clear,attr,omitempty"`
 }
 
 // Em ...
@@ -889,23 +889,23 @@ type Font struct {
 type Object struct {
 	XMLName      xml.Name `xml:"object"`
 	Attrs        *Attrs
-	DeclareAttr  interface{} `xml:"declare,attr,omitempty"`
-	ClassidAttr  string      `xml:"classid,attr,omitempty"`
-	CodebaseAttr string      `xml:"codebase,attr,omitempty"`
-	DataAttr     string      `xml:"data,attr,omitempty"`
-	TypeAttr     string      `xml:"type,attr,omitempty"`
-	CodetypeAttr string      `xml:"codetype,attr,omitempty"`
-	ArchiveAttr  string      `xml:"archive,attr,omitempty"`
-	StandbyAttr  string      `xml:"standby,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   int         `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	DeclareAttr  string `xml:"declare,attr,omitempty"`
+	ClassidAttr  string `xml:"classid,attr,omitempty"`
+	CodebaseAttr string `xml:"codebase,attr,omitempty"`
+	DataAttr     string `xml:"data,attr,omitempty"`
+	TypeAttr     string `xml:"type,attr,omitempty"`
+	CodetypeAttr string `xml:"codetype,attr,omitempty"`
+	ArchiveAttr  string `xml:"archive,attr,omitempty"`
+	StandbyAttr  string `xml:"standby,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	TabindexAttr int    `xml:"tabindex,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   int    `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 	Block        *Block
 	Inline       *Inline
 	Misc         *Misc
@@ -919,7 +919,7 @@ type Param struct {
 	IdAttr        string      `xml:"id,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	ValuetypeAttr interface{} `xml:"valuetype,attr,omitempty"`
+	ValuetypeAttr string      `xml:"valuetype,attr,omitempty"`
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 }
 
@@ -949,18 +949,18 @@ type Applet struct {
 type Img struct {
 	XMLName      xml.Name `xml:"img"`
 	Attrs        *Attrs
-	SrcAttr      string      `xml:"src,attr"`
-	AltAttr      string      `xml:"alt,attr"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	LongdescAttr string      `xml:"longdesc,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	IsmapAttr    interface{} `xml:"ismap,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   string      `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	SrcAttr      string `xml:"src,attr"`
+	AltAttr      string `xml:"alt,attr"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	LongdescAttr string `xml:"longdesc,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	IsmapAttr    string `xml:"ismap,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   string `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 }
 
 // Map ...
@@ -984,26 +984,26 @@ type Area struct {
 	XMLName    xml.Name `xml:"area"`
 	Attrs      *Attrs
 	Focus      *Focus
-	ShapeAttr  string      `xml:"shape,attr,omitempty"`
-	CoordsAttr string      `xml:"coords,attr,omitempty"`
-	HrefAttr   string      `xml:"href,attr,omitempty"`
-	NohrefAttr interface{} `xml:"nohref,attr,omitempty"`
-	AltAttr    string      `xml:"alt,attr"`
-	TargetAttr string      `xml:"target,attr,omitempty"`
+	ShapeAttr  string `xml:"shape,attr,omitempty"`
+	CoordsAttr string `xml:"coords,attr,omitempty"`
+	HrefAttr   string `xml:"href,attr,omitempty"`
+	NohrefAttr string `xml:"nohref,attr,omitempty"`
+	AltAttr    string `xml:"alt,attr"`
+	TargetAttr string `xml:"target,attr,omitempty"`
 }
 
 // Form ...
 type Form struct {
 	XMLName           xml.Name `xml:"form"`
 	Attrs             *Attrs
-	ActionAttr        string      `xml:"action,attr"`
-	MethodAttr        interface{} `xml:"method,attr,omitempty"`
-	EnctypeAttr       string      `xml:"enctype,attr,omitempty"`
-	OnsubmitAttr      string      `xml:"onsubmit,attr,omitempty"`
-	OnresetAttr       string      `xml:"onreset,attr,omitempty"`
-	AcceptAttr        string      `xml:"accept,attr,omitempty"`
-	AcceptcharsetAttr string      `xml:"accept-charset,attr,omitempty"`
-	TargetAttr        string      `xml:"target,attr,omitempty"`
+	ActionAttr        string `xml:"action,attr"`
+	MethodAttr        string `xml:"method,attr,omitempty"`
+	EnctypeAttr       string `xml:"enctype,attr,omitempty"`
+	OnsubmitAttr      string `xml:"onsubmit,attr,omitempty"`
+	OnresetAttr       string `xml:"onreset,attr,omitempty"`
+	AcceptAttr        string `xml:"accept,attr,omitempty"`
+	AcceptcharsetAttr string `xml:"accept-charset,attr,omitempty"`
+	TargetAttr        string `xml:"target,attr,omitempty"`
 }
 
 // Label ...
@@ -1027,9 +1027,9 @@ type Input struct {
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr,omitempty"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	CheckedAttr   interface{} `xml:"checked,attr,omitempty"`
-	DisabledAttr  interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr  interface{} `xml:"readonly,attr,omitempty"`
+	CheckedAttr   string      `xml:"checked,attr,omitempty"`
+	DisabledAttr  string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr  string      `xml:"readonly,attr,omitempty"`
 	SizeAttr      interface{} `xml:"size,attr,omitempty"`
 	MaxlengthAttr int         `xml:"maxlength,attr,omitempty"`
 	SrcAttr       string      `xml:"src,attr,omitempty"`
@@ -1047,8 +1047,8 @@ type Select struct {
 	Attrs        *Attrs
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	SizeAttr     int         `xml:"size,attr,omitempty"`
-	MultipleAttr interface{} `xml:"multiple,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	MultipleAttr string      `xml:"multiple,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
 	OnfocusAttr  string      `xml:"onfocus,attr,omitempty"`
 	OnblurAttr   string      `xml:"onblur,attr,omitempty"`
@@ -1061,17 +1061,17 @@ type Select struct {
 type Optgroup struct {
 	XMLName      xml.Name `xml:"optgroup"`
 	Attrs        *Attrs
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	LabelAttr    string      `xml:"label,attr"`
-	Optgroup     string      `xml:"optgroup"`
+	DisabledAttr string `xml:"disabled,attr,omitempty"`
+	LabelAttr    string `xml:"label,attr"`
+	Optgroup     string `xml:"optgroup"`
 }
 
 // Option ...
 type Option struct {
 	XMLName      xml.Name `xml:"option"`
 	Attrs        *Attrs
-	SelectedAttr interface{} `xml:"selected,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	SelectedAttr string      `xml:"selected,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	LabelAttr    string      `xml:"label,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
 }
@@ -1084,8 +1084,8 @@ type Textarea struct {
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	RowsAttr     int         `xml:"rows,attr"`
 	ColsAttr     int         `xml:"cols,attr"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr interface{} `xml:"readonly,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr string      `xml:"readonly,attr,omitempty"`
 	OnselectAttr string      `xml:"onselect,attr,omitempty"`
 	OnchangeAttr string      `xml:"onchange,attr,omitempty"`
 }
@@ -1119,8 +1119,8 @@ type Button struct {
 	Focus        *Focus
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
-	TypeAttr     interface{} `xml:"type,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	TypeAttr     string      `xml:"type,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 }
 
 // Isindex ...
@@ -1271,7 +1271,7 @@ type Th struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`
@@ -1289,7 +1289,7 @@ type Td struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`

--- a/go/maven.apache.org/xdoc-2.0.xsd.go
+++ b/go/maven.apache.org/xdoc-2.0.xsd.go
@@ -474,7 +474,7 @@ type Script struct {
 	TypeAttr     string      `xml:"type,attr"`
 	LanguageAttr interface{} `xml:"language,attr,omitempty"`
 	SrcAttr      string      `xml:"src,attr,omitempty"`
-	DeferAttr    interface{} `xml:"defer,attr,omitempty"`
+	DeferAttr    string      `xml:"defer,attr,omitempty"`
 	XmlSpaceAttr *Space      `xml:"xml:space,attr,omitempty"`
 }
 
@@ -488,16 +488,16 @@ type Noscript struct {
 type Iframe struct {
 	XMLName          xml.Name `xml:"iframe"`
 	Coreattrs        *Coreattrs
-	LongdescAttr     string      `xml:"longdesc,attr,omitempty"`
-	NameAttr         string      `xml:"name,attr,omitempty"`
-	SrcAttr          string      `xml:"src,attr,omitempty"`
-	FrameborderAttr  interface{} `xml:"frameborder,attr,omitempty"`
-	MarginwidthAttr  int         `xml:"marginwidth,attr,omitempty"`
-	MarginheightAttr int         `xml:"marginheight,attr,omitempty"`
-	ScrollingAttr    interface{} `xml:"scrolling,attr,omitempty"`
-	AlignAttr        string      `xml:"align,attr,omitempty"`
-	HeightAttr       string      `xml:"height,attr,omitempty"`
-	WidthAttr        string      `xml:"width,attr,omitempty"`
+	LongdescAttr     string `xml:"longdesc,attr,omitempty"`
+	NameAttr         string `xml:"name,attr,omitempty"`
+	SrcAttr          string `xml:"src,attr,omitempty"`
+	FrameborderAttr  string `xml:"frameborder,attr,omitempty"`
+	MarginwidthAttr  int    `xml:"marginwidth,attr,omitempty"`
+	MarginheightAttr int    `xml:"marginheight,attr,omitempty"`
+	ScrollingAttr    string `xml:"scrolling,attr,omitempty"`
+	AlignAttr        string `xml:"align,attr,omitempty"`
+	HeightAttr       string `xml:"height,attr,omitempty"`
+	WidthAttr        string `xml:"width,attr,omitempty"`
 }
 
 // Noframes ...
@@ -569,9 +569,9 @@ type ULStyle string
 type Ul struct {
 	XMLName     xml.Name `xml:"ul"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Ul          string      `xml:"ul"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Ul          string `xml:"ul"`
 }
 
 // OLStyle is Ordered list numbering style
@@ -590,26 +590,26 @@ type OLStyle string
 type Ol struct {
 	XMLName     xml.Name `xml:"ol"`
 	Attrs       *Attrs
-	TypeAttr    string      `xml:"type,attr,omitempty"`
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	StartAttr   int         `xml:"start,attr,omitempty"`
-	Ol          string      `xml:"ol"`
+	TypeAttr    string `xml:"type,attr,omitempty"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	StartAttr   int    `xml:"start,attr,omitempty"`
+	Ol          string `xml:"ol"`
 }
 
 // Menu ...
 type Menu struct {
 	XMLName     xml.Name `xml:"menu"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Menu        string      `xml:"menu"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Menu        string `xml:"menu"`
 }
 
 // Dir ...
 type Dir struct {
 	XMLName     xml.Name `xml:"dir"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dir         string      `xml:"dir"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dir         string `xml:"dir"`
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
@@ -627,9 +627,9 @@ type Li struct {
 type Dl struct {
 	XMLName     xml.Name `xml:"dl"`
 	Attrs       *Attrs
-	CompactAttr interface{} `xml:"compact,attr,omitempty"`
-	Dt          *Dt         `xml:"dt"`
-	Dl          string      `xml:"dl"`
+	CompactAttr string `xml:"compact,attr,omitempty"`
+	Dt          *Dt    `xml:"dt"`
+	Dl          string `xml:"dl"`
 }
 
 // Dt ...
@@ -657,10 +657,10 @@ type Address struct {
 type Hr struct {
 	XMLName     xml.Name `xml:"hr"`
 	Attrs       *Attrs
-	AlignAttr   interface{} `xml:"align,attr,omitempty"`
-	NoshadeAttr interface{} `xml:"noshade,attr,omitempty"`
-	SizeAttr    int         `xml:"size,attr,omitempty"`
-	WidthAttr   string      `xml:"width,attr,omitempty"`
+	AlignAttr   string `xml:"align,attr,omitempty"`
+	NoshadeAttr string `xml:"noshade,attr,omitempty"`
+	SizeAttr    int    `xml:"size,attr,omitempty"`
+	WidthAttr   string `xml:"width,attr,omitempty"`
 }
 
 // Pre ...
@@ -728,16 +728,16 @@ type Bdo struct {
 	XMLName     xml.Name `xml:"bdo"`
 	Coreattrs   *Coreattrs
 	Events      *Events
-	LangAttr    string      `xml:"lang,attr,omitempty"`
-	XmlLangAttr *Lang       `xml:"xml:lang,attr,omitempty"`
-	DirAttr     interface{} `xml:"dir,attr"`
+	LangAttr    string `xml:"lang,attr,omitempty"`
+	XmlLangAttr *Lang  `xml:"xml:lang,attr,omitempty"`
+	DirAttr     string `xml:"dir,attr"`
 }
 
 // Br ...
 type Br struct {
 	XMLName   xml.Name `xml:"br"`
 	Coreattrs *Coreattrs
-	ClearAttr interface{} `xml:"clear,attr,omitempty"`
+	ClearAttr string `xml:"clear,attr,omitempty"`
 }
 
 // Em ...
@@ -890,23 +890,23 @@ type Font struct {
 type Object struct {
 	XMLName      xml.Name `xml:"object"`
 	Attrs        *Attrs
-	DeclareAttr  interface{} `xml:"declare,attr,omitempty"`
-	ClassidAttr  string      `xml:"classid,attr,omitempty"`
-	CodebaseAttr string      `xml:"codebase,attr,omitempty"`
-	DataAttr     string      `xml:"data,attr,omitempty"`
-	TypeAttr     string      `xml:"type,attr,omitempty"`
-	CodetypeAttr string      `xml:"codetype,attr,omitempty"`
-	ArchiveAttr  string      `xml:"archive,attr,omitempty"`
-	StandbyAttr  string      `xml:"standby,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   int         `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	DeclareAttr  string `xml:"declare,attr,omitempty"`
+	ClassidAttr  string `xml:"classid,attr,omitempty"`
+	CodebaseAttr string `xml:"codebase,attr,omitempty"`
+	DataAttr     string `xml:"data,attr,omitempty"`
+	TypeAttr     string `xml:"type,attr,omitempty"`
+	CodetypeAttr string `xml:"codetype,attr,omitempty"`
+	ArchiveAttr  string `xml:"archive,attr,omitempty"`
+	StandbyAttr  string `xml:"standby,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	TabindexAttr int    `xml:"tabindex,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   int    `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 	Block        *Block
 	Inline       *Inline
 	Misc         *Misc
@@ -920,7 +920,7 @@ type Param struct {
 	IdAttr        string      `xml:"id,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	ValuetypeAttr interface{} `xml:"valuetype,attr,omitempty"`
+	ValuetypeAttr string      `xml:"valuetype,attr,omitempty"`
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 }
 
@@ -950,18 +950,18 @@ type Applet struct {
 type Img struct {
 	XMLName      xml.Name `xml:"img"`
 	Attrs        *Attrs
-	SrcAttr      string      `xml:"src,attr"`
-	AltAttr      string      `xml:"alt,attr"`
-	NameAttr     string      `xml:"name,attr,omitempty"`
-	LongdescAttr string      `xml:"longdesc,attr,omitempty"`
-	HeightAttr   string      `xml:"height,attr,omitempty"`
-	WidthAttr    string      `xml:"width,attr,omitempty"`
-	UsemapAttr   string      `xml:"usemap,attr,omitempty"`
-	IsmapAttr    interface{} `xml:"ismap,attr,omitempty"`
-	AlignAttr    string      `xml:"align,attr,omitempty"`
-	BorderAttr   string      `xml:"border,attr,omitempty"`
-	HspaceAttr   int         `xml:"hspace,attr,omitempty"`
-	VspaceAttr   int         `xml:"vspace,attr,omitempty"`
+	SrcAttr      string `xml:"src,attr"`
+	AltAttr      string `xml:"alt,attr"`
+	NameAttr     string `xml:"name,attr,omitempty"`
+	LongdescAttr string `xml:"longdesc,attr,omitempty"`
+	HeightAttr   string `xml:"height,attr,omitempty"`
+	WidthAttr    string `xml:"width,attr,omitempty"`
+	UsemapAttr   string `xml:"usemap,attr,omitempty"`
+	IsmapAttr    string `xml:"ismap,attr,omitempty"`
+	AlignAttr    string `xml:"align,attr,omitempty"`
+	BorderAttr   string `xml:"border,attr,omitempty"`
+	HspaceAttr   int    `xml:"hspace,attr,omitempty"`
+	VspaceAttr   int    `xml:"vspace,attr,omitempty"`
 }
 
 // Map ...
@@ -985,26 +985,26 @@ type Area struct {
 	XMLName    xml.Name `xml:"area"`
 	Attrs      *Attrs
 	Focus      *Focus
-	ShapeAttr  string      `xml:"shape,attr,omitempty"`
-	CoordsAttr string      `xml:"coords,attr,omitempty"`
-	HrefAttr   string      `xml:"href,attr,omitempty"`
-	NohrefAttr interface{} `xml:"nohref,attr,omitempty"`
-	AltAttr    string      `xml:"alt,attr"`
-	TargetAttr string      `xml:"target,attr,omitempty"`
+	ShapeAttr  string `xml:"shape,attr,omitempty"`
+	CoordsAttr string `xml:"coords,attr,omitempty"`
+	HrefAttr   string `xml:"href,attr,omitempty"`
+	NohrefAttr string `xml:"nohref,attr,omitempty"`
+	AltAttr    string `xml:"alt,attr"`
+	TargetAttr string `xml:"target,attr,omitempty"`
 }
 
 // Form ...
 type Form struct {
 	XMLName           xml.Name `xml:"form"`
 	Attrs             *Attrs
-	ActionAttr        string      `xml:"action,attr"`
-	MethodAttr        interface{} `xml:"method,attr,omitempty"`
-	EnctypeAttr       string      `xml:"enctype,attr,omitempty"`
-	OnsubmitAttr      string      `xml:"onsubmit,attr,omitempty"`
-	OnresetAttr       string      `xml:"onreset,attr,omitempty"`
-	AcceptAttr        string      `xml:"accept,attr,omitempty"`
-	AcceptcharsetAttr string      `xml:"accept-charset,attr,omitempty"`
-	TargetAttr        string      `xml:"target,attr,omitempty"`
+	ActionAttr        string `xml:"action,attr"`
+	MethodAttr        string `xml:"method,attr,omitempty"`
+	EnctypeAttr       string `xml:"enctype,attr,omitempty"`
+	OnsubmitAttr      string `xml:"onsubmit,attr,omitempty"`
+	OnresetAttr       string `xml:"onreset,attr,omitempty"`
+	AcceptAttr        string `xml:"accept,attr,omitempty"`
+	AcceptcharsetAttr string `xml:"accept-charset,attr,omitempty"`
+	TargetAttr        string `xml:"target,attr,omitempty"`
 }
 
 // Label ...
@@ -1028,9 +1028,9 @@ type Input struct {
 	TypeAttr      string      `xml:"type,attr,omitempty"`
 	NameAttr      interface{} `xml:"name,attr,omitempty"`
 	ValueAttr     interface{} `xml:"value,attr,omitempty"`
-	CheckedAttr   interface{} `xml:"checked,attr,omitempty"`
-	DisabledAttr  interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr  interface{} `xml:"readonly,attr,omitempty"`
+	CheckedAttr   string      `xml:"checked,attr,omitempty"`
+	DisabledAttr  string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr  string      `xml:"readonly,attr,omitempty"`
 	SizeAttr      interface{} `xml:"size,attr,omitempty"`
 	MaxlengthAttr int         `xml:"maxlength,attr,omitempty"`
 	SrcAttr       string      `xml:"src,attr,omitempty"`
@@ -1048,8 +1048,8 @@ type Select struct {
 	Attrs        *Attrs
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	SizeAttr     int         `xml:"size,attr,omitempty"`
-	MultipleAttr interface{} `xml:"multiple,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	MultipleAttr string      `xml:"multiple,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	TabindexAttr int         `xml:"tabindex,attr,omitempty"`
 	OnfocusAttr  string      `xml:"onfocus,attr,omitempty"`
 	OnblurAttr   string      `xml:"onblur,attr,omitempty"`
@@ -1062,17 +1062,17 @@ type Select struct {
 type Optgroup struct {
 	XMLName      xml.Name `xml:"optgroup"`
 	Attrs        *Attrs
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	LabelAttr    string      `xml:"label,attr"`
-	Optgroup     string      `xml:"optgroup"`
+	DisabledAttr string `xml:"disabled,attr,omitempty"`
+	LabelAttr    string `xml:"label,attr"`
+	Optgroup     string `xml:"optgroup"`
 }
 
 // Option ...
 type Option struct {
 	XMLName      xml.Name `xml:"option"`
 	Attrs        *Attrs
-	SelectedAttr interface{} `xml:"selected,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	SelectedAttr string      `xml:"selected,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 	LabelAttr    string      `xml:"label,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
 }
@@ -1085,8 +1085,8 @@ type Textarea struct {
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	RowsAttr     int         `xml:"rows,attr"`
 	ColsAttr     int         `xml:"cols,attr"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
-	ReadonlyAttr interface{} `xml:"readonly,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
+	ReadonlyAttr string      `xml:"readonly,attr,omitempty"`
 	OnselectAttr string      `xml:"onselect,attr,omitempty"`
 	OnchangeAttr string      `xml:"onchange,attr,omitempty"`
 }
@@ -1120,8 +1120,8 @@ type Button struct {
 	Focus        *Focus
 	NameAttr     interface{} `xml:"name,attr,omitempty"`
 	ValueAttr    interface{} `xml:"value,attr,omitempty"`
-	TypeAttr     interface{} `xml:"type,attr,omitempty"`
-	DisabledAttr interface{} `xml:"disabled,attr,omitempty"`
+	TypeAttr     string      `xml:"type,attr,omitempty"`
+	DisabledAttr string      `xml:"disabled,attr,omitempty"`
 }
 
 // Isindex ...
@@ -1272,7 +1272,7 @@ type Th struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`
@@ -1290,7 +1290,7 @@ type Td struct {
 	ScopeAttr   string      `xml:"scope,attr,omitempty"`
 	RowspanAttr int         `xml:"rowspan,attr,omitempty"`
 	ColspanAttr int         `xml:"colspan,attr,omitempty"`
-	NowrapAttr  interface{} `xml:"nowrap,attr,omitempty"`
+	NowrapAttr  string      `xml:"nowrap,attr,omitempty"`
 	BgcolorAttr string      `xml:"bgcolor,attr,omitempty"`
 	WidthAttr   string      `xml:"width,attr,omitempty"`
 	HeightAttr  string      `xml:"height,attr,omitempty"`

--- a/ts/maven.apache.org/fml-1.0.1.xsd.ts
+++ b/ts/maven.apache.org/fml-1.0.1.xsd.ts
@@ -444,7 +444,7 @@ export class Script {
 	TypeAttr: string;
 	LanguageAttr: any | null;
 	SrcAttr: string | null;
-	DeferAttr: any | null;
+	DeferAttr: string | null;
 	XmlSpaceAttr: Space | null;
 }
 
@@ -459,10 +459,10 @@ export class Iframe {
 	LongdescAttr: string | null;
 	NameAttr: string | null;
 	SrcAttr: string | null;
-	FrameborderAttr: any | null;
+	FrameborderAttr: string | null;
 	MarginwidthAttr: number | null;
 	MarginheightAttr: number | null;
-	ScrollingAttr: any | null;
+	ScrollingAttr: string | null;
 	AlignAttr: string | null;
 	HeightAttr: string | null;
 	WidthAttr: string | null;
@@ -523,12 +523,6 @@ export class H6 {
 
 // ULStyle is Unordered list bullet styles
 export enum ULStyle {
-	defer = 'defer',
-	1 = '1',
-	0 = '0',
-	yes = 'yes',
-	no = 'no',
-	auto = 'auto',
 	disc = 'disc',
 	square = 'square',
 	circle = 'circle',
@@ -538,7 +532,7 @@ export enum ULStyle {
 export class Ul {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Ul: string;
 }
 
@@ -552,15 +546,13 @@ export class Ul {
 // 
 //       The style is applied to the sequence number which by default
 //       is reset to 1 for the first list item in an ordered list.
-export enum OLStyle {
-	compact = 'compact',
-}
+export type OLStyle = string;
 
 // Ol ...
 export class Ol {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	StartAttr: number | null;
 	Ol: string;
 }
@@ -568,23 +560,19 @@ export class Ol {
 // Menu ...
 export class Menu {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Menu: string;
 }
 
 // Dir ...
 export class Dir {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dir: string;
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
-export enum LIStyle {
-	compact = 'compact',
-	compact = 'compact',
-	compact = 'compact',
-}
+export type LIStyle = string;
 
 // Li ...
 export class Li {
@@ -596,7 +584,7 @@ export class Li {
 // Dl ...
 export class Dl {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dt: Dt;
 	Dl: string;
 }
@@ -622,8 +610,8 @@ export class Address {
 // Hr ...
 export class Hr {
 	Attrs: Attrs;
-	AlignAttr: any | null;
-	NoshadeAttr: any | null;
+	AlignAttr: string | null;
+	NoshadeAttr: string | null;
 	SizeAttr: number | null;
 	WidthAttr: string | null;
 }
@@ -687,13 +675,13 @@ export class Bdo {
 	Events: Events;
 	LangAttr: string | null;
 	XmlLangAttr: Lang | null;
-	DirAttr: any;
+	DirAttr: string;
 }
 
 // Br ...
 export class Br {
 	Coreattrs: Coreattrs;
-	ClearAttr: any | null;
+	ClearAttr: string | null;
 }
 
 // Em ...
@@ -822,7 +810,7 @@ export class Font {
 // Object ...
 export class Object {
 	Attrs: Attrs;
-	DeclareAttr: any | null;
+	DeclareAttr: string | null;
 	ClassidAttr: string | null;
 	CodebaseAttr: string | null;
 	DataAttr: string | null;
@@ -851,7 +839,7 @@ export class Param {
 	IdAttr: string | null;
 	NameAttr: any;
 	ValueAttr: any | null;
-	ValuetypeAttr: any | null;
+	ValuetypeAttr: string | null;
 	TypeAttr: string | null;
 }
 
@@ -886,7 +874,7 @@ export class Img {
 	HeightAttr: string | null;
 	WidthAttr: string | null;
 	UsemapAttr: string | null;
-	IsmapAttr: any | null;
+	IsmapAttr: string | null;
 	AlignAttr: string | null;
 	BorderAttr: string | null;
 	HspaceAttr: number | null;
@@ -915,7 +903,7 @@ export class Area {
 	ShapeAttr: string | null;
 	CoordsAttr: string | null;
 	HrefAttr: string | null;
-	NohrefAttr: any | null;
+	NohrefAttr: string | null;
 	AltAttr: string;
 	TargetAttr: string | null;
 }
@@ -924,7 +912,7 @@ export class Area {
 export class Form {
 	Attrs: Attrs;
 	ActionAttr: string;
-	MethodAttr: any | null;
+	MethodAttr: string | null;
 	EnctypeAttr: string | null;
 	OnsubmitAttr: string | null;
 	OnresetAttr: string | null;
@@ -944,25 +932,6 @@ export class Label {
 
 // InputType ...
 export enum InputType {
-	compact = 'compact',
-	left = 'left',
-	center = 'center',
-	right = 'right',
-	noshade = 'noshade',
-	ltr = 'ltr',
-	rtl = 'rtl',
-	left = 'left',
-	all = 'all',
-	right = 'right',
-	none = 'none',
-	declare = 'declare',
-	data = 'data',
-	ref = 'ref',
-	object = 'object',
-	ismap = 'ismap',
-	nohref = 'nohref',
-	get = 'get',
-	post = 'post',
 	text = 'text',
 	password = 'password',
 	checkbox = 'checkbox',
@@ -982,9 +951,9 @@ export class Input {
 	TypeAttr: string | null;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	CheckedAttr: any | null;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	CheckedAttr: string | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	SizeAttr: any | null;
 	MaxlengthAttr: number | null;
 	SrcAttr: string | null;
@@ -1001,8 +970,8 @@ export class Select {
 	Attrs: Attrs;
 	NameAttr: any | null;
 	SizeAttr: number | null;
-	MultipleAttr: any | null;
-	DisabledAttr: any | null;
+	MultipleAttr: string | null;
+	DisabledAttr: string | null;
 	TabindexAttr: number | null;
 	OnfocusAttr: string | null;
 	OnblurAttr: string | null;
@@ -1014,7 +983,7 @@ export class Select {
 // Optgroup ...
 export class Optgroup {
 	Attrs: Attrs;
-	DisabledAttr: any | null;
+	DisabledAttr: string | null;
 	LabelAttr: string;
 	Optgroup: string;
 }
@@ -1022,8 +991,8 @@ export class Optgroup {
 // Option ...
 export class Option {
 	Attrs: Attrs;
-	SelectedAttr: any | null;
-	DisabledAttr: any | null;
+	SelectedAttr: string | null;
+	DisabledAttr: string | null;
 	LabelAttr: string | null;
 	ValueAttr: any | null;
 }
@@ -1035,8 +1004,8 @@ export class Textarea {
 	NameAttr: any | null;
 	RowsAttr: number;
 	ColsAttr: number;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	OnselectAttr: string | null;
 	OnchangeAttr: string | null;
 }
@@ -1053,16 +1022,6 @@ export class Fieldset {
 
 // LAlign ...
 export enum LAlign {
-	checked = 'checked',
-	disabled = 'disabled',
-	readonly = 'readonly',
-	multiple = 'multiple',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	selected = 'selected',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	readonly = 'readonly',
 	top = 'top',
 	bottom = 'bottom',
 	left = 'left',
@@ -1082,8 +1041,8 @@ export class Button {
 	Focus: Focus;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	TypeAttr: any | null;
-	DisabledAttr: any | null;
+	TypeAttr: string | null;
+	DisabledAttr: string | null;
 }
 
 // Isindex ...
@@ -1100,10 +1059,6 @@ export class Isindex {
 //       the table should be rendered. The values are not the same as
 //       CALS to avoid a name clash with the valign attribute.
 export enum TFrame {
-	button = 'button',
-	submit = 'submit',
-	reset = 'reset',
-	disabled = 'disabled',
 	void = 'void',
 	above = 'above',
 	below = 'below',
@@ -1256,7 +1211,7 @@ export class Th {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;
@@ -1273,7 +1228,7 @@ export class Td {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;

--- a/ts/maven.apache.org/fml-1.0.xsd.ts
+++ b/ts/maven.apache.org/fml-1.0.xsd.ts
@@ -443,7 +443,7 @@ export class Script {
 	TypeAttr: string;
 	LanguageAttr: any | null;
 	SrcAttr: string | null;
-	DeferAttr: any | null;
+	DeferAttr: string | null;
 	XmlSpaceAttr: Space | null;
 }
 
@@ -458,10 +458,10 @@ export class Iframe {
 	LongdescAttr: string | null;
 	NameAttr: string | null;
 	SrcAttr: string | null;
-	FrameborderAttr: any | null;
+	FrameborderAttr: string | null;
 	MarginwidthAttr: number | null;
 	MarginheightAttr: number | null;
-	ScrollingAttr: any | null;
+	ScrollingAttr: string | null;
 	AlignAttr: string | null;
 	HeightAttr: string | null;
 	WidthAttr: string | null;
@@ -522,12 +522,6 @@ export class H6 {
 
 // ULStyle is Unordered list bullet styles
 export enum ULStyle {
-	defer = 'defer',
-	1 = '1',
-	0 = '0',
-	yes = 'yes',
-	no = 'no',
-	auto = 'auto',
 	disc = 'disc',
 	square = 'square',
 	circle = 'circle',
@@ -537,7 +531,7 @@ export enum ULStyle {
 export class Ul {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Ul: string;
 }
 
@@ -551,15 +545,13 @@ export class Ul {
 // 
 //       The style is applied to the sequence number which by default
 //       is reset to 1 for the first list item in an ordered list.
-export enum OLStyle {
-	compact = 'compact',
-}
+export type OLStyle = string;
 
 // Ol ...
 export class Ol {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	StartAttr: number | null;
 	Ol: string;
 }
@@ -567,23 +559,19 @@ export class Ol {
 // Menu ...
 export class Menu {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Menu: string;
 }
 
 // Dir ...
 export class Dir {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dir: string;
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
-export enum LIStyle {
-	compact = 'compact',
-	compact = 'compact',
-	compact = 'compact',
-}
+export type LIStyle = string;
 
 // Li ...
 export class Li {
@@ -595,7 +583,7 @@ export class Li {
 // Dl ...
 export class Dl {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dt: Dt;
 	Dl: string;
 }
@@ -621,8 +609,8 @@ export class Address {
 // Hr ...
 export class Hr {
 	Attrs: Attrs;
-	AlignAttr: any | null;
-	NoshadeAttr: any | null;
+	AlignAttr: string | null;
+	NoshadeAttr: string | null;
 	SizeAttr: number | null;
 	WidthAttr: string | null;
 }
@@ -686,13 +674,13 @@ export class Bdo {
 	Events: Events;
 	LangAttr: string | null;
 	XmlLangAttr: Lang | null;
-	DirAttr: any;
+	DirAttr: string;
 }
 
 // Br ...
 export class Br {
 	Coreattrs: Coreattrs;
-	ClearAttr: any | null;
+	ClearAttr: string | null;
 }
 
 // Em ...
@@ -821,7 +809,7 @@ export class Font {
 // Object ...
 export class Object {
 	Attrs: Attrs;
-	DeclareAttr: any | null;
+	DeclareAttr: string | null;
 	ClassidAttr: string | null;
 	CodebaseAttr: string | null;
 	DataAttr: string | null;
@@ -850,7 +838,7 @@ export class Param {
 	IdAttr: string | null;
 	NameAttr: any;
 	ValueAttr: any | null;
-	ValuetypeAttr: any | null;
+	ValuetypeAttr: string | null;
 	TypeAttr: string | null;
 }
 
@@ -885,7 +873,7 @@ export class Img {
 	HeightAttr: string | null;
 	WidthAttr: string | null;
 	UsemapAttr: string | null;
-	IsmapAttr: any | null;
+	IsmapAttr: string | null;
 	AlignAttr: string | null;
 	BorderAttr: string | null;
 	HspaceAttr: number | null;
@@ -914,7 +902,7 @@ export class Area {
 	ShapeAttr: string | null;
 	CoordsAttr: string | null;
 	HrefAttr: string | null;
-	NohrefAttr: any | null;
+	NohrefAttr: string | null;
 	AltAttr: string;
 	TargetAttr: string | null;
 }
@@ -923,7 +911,7 @@ export class Area {
 export class Form {
 	Attrs: Attrs;
 	ActionAttr: string;
-	MethodAttr: any | null;
+	MethodAttr: string | null;
 	EnctypeAttr: string | null;
 	OnsubmitAttr: string | null;
 	OnresetAttr: string | null;
@@ -943,25 +931,6 @@ export class Label {
 
 // InputType ...
 export enum InputType {
-	compact = 'compact',
-	left = 'left',
-	center = 'center',
-	right = 'right',
-	noshade = 'noshade',
-	ltr = 'ltr',
-	rtl = 'rtl',
-	left = 'left',
-	all = 'all',
-	right = 'right',
-	none = 'none',
-	declare = 'declare',
-	data = 'data',
-	ref = 'ref',
-	object = 'object',
-	ismap = 'ismap',
-	nohref = 'nohref',
-	get = 'get',
-	post = 'post',
 	text = 'text',
 	password = 'password',
 	checkbox = 'checkbox',
@@ -981,9 +950,9 @@ export class Input {
 	TypeAttr: string | null;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	CheckedAttr: any | null;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	CheckedAttr: string | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	SizeAttr: any | null;
 	MaxlengthAttr: number | null;
 	SrcAttr: string | null;
@@ -1000,8 +969,8 @@ export class Select {
 	Attrs: Attrs;
 	NameAttr: any | null;
 	SizeAttr: number | null;
-	MultipleAttr: any | null;
-	DisabledAttr: any | null;
+	MultipleAttr: string | null;
+	DisabledAttr: string | null;
 	TabindexAttr: number | null;
 	OnfocusAttr: string | null;
 	OnblurAttr: string | null;
@@ -1013,7 +982,7 @@ export class Select {
 // Optgroup ...
 export class Optgroup {
 	Attrs: Attrs;
-	DisabledAttr: any | null;
+	DisabledAttr: string | null;
 	LabelAttr: string;
 	Optgroup: string;
 }
@@ -1021,8 +990,8 @@ export class Optgroup {
 // Option ...
 export class Option {
 	Attrs: Attrs;
-	SelectedAttr: any | null;
-	DisabledAttr: any | null;
+	SelectedAttr: string | null;
+	DisabledAttr: string | null;
 	LabelAttr: string | null;
 	ValueAttr: any | null;
 }
@@ -1034,8 +1003,8 @@ export class Textarea {
 	NameAttr: any | null;
 	RowsAttr: number;
 	ColsAttr: number;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	OnselectAttr: string | null;
 	OnchangeAttr: string | null;
 }
@@ -1052,16 +1021,6 @@ export class Fieldset {
 
 // LAlign ...
 export enum LAlign {
-	checked = 'checked',
-	disabled = 'disabled',
-	readonly = 'readonly',
-	multiple = 'multiple',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	selected = 'selected',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	readonly = 'readonly',
 	top = 'top',
 	bottom = 'bottom',
 	left = 'left',
@@ -1081,8 +1040,8 @@ export class Button {
 	Focus: Focus;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	TypeAttr: any | null;
-	DisabledAttr: any | null;
+	TypeAttr: string | null;
+	DisabledAttr: string | null;
 }
 
 // Isindex ...
@@ -1099,10 +1058,6 @@ export class Isindex {
 //       the table should be rendered. The values are not the same as
 //       CALS to avoid a name clash with the valign attribute.
 export enum TFrame {
-	button = 'button',
-	submit = 'submit',
-	reset = 'reset',
-	disabled = 'disabled',
 	void = 'void',
 	above = 'above',
 	below = 'below',
@@ -1255,7 +1210,7 @@ export class Th {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;
@@ -1272,7 +1227,7 @@ export class Td {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;

--- a/ts/maven.apache.org/xdoc-2.0.xsd.ts
+++ b/ts/maven.apache.org/xdoc-2.0.xsd.ts
@@ -444,7 +444,7 @@ export class Script {
 	TypeAttr: string;
 	LanguageAttr: any | null;
 	SrcAttr: string | null;
-	DeferAttr: any | null;
+	DeferAttr: string | null;
 	XmlSpaceAttr: Space | null;
 }
 
@@ -459,10 +459,10 @@ export class Iframe {
 	LongdescAttr: string | null;
 	NameAttr: string | null;
 	SrcAttr: string | null;
-	FrameborderAttr: any | null;
+	FrameborderAttr: string | null;
 	MarginwidthAttr: number | null;
 	MarginheightAttr: number | null;
-	ScrollingAttr: any | null;
+	ScrollingAttr: string | null;
 	AlignAttr: string | null;
 	HeightAttr: string | null;
 	WidthAttr: string | null;
@@ -523,12 +523,6 @@ export class H6 {
 
 // ULStyle is Unordered list bullet styles
 export enum ULStyle {
-	defer = 'defer',
-	1 = '1',
-	0 = '0',
-	yes = 'yes',
-	no = 'no',
-	auto = 'auto',
 	disc = 'disc',
 	square = 'square',
 	circle = 'circle',
@@ -538,7 +532,7 @@ export enum ULStyle {
 export class Ul {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Ul: string;
 }
 
@@ -552,15 +546,13 @@ export class Ul {
 // 
 //       The style is applied to the sequence number which by default
 //       is reset to 1 for the first list item in an ordered list.
-export enum OLStyle {
-	compact = 'compact',
-}
+export type OLStyle = string;
 
 // Ol ...
 export class Ol {
 	Attrs: Attrs;
 	TypeAttr: string | null;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	StartAttr: number | null;
 	Ol: string;
 }
@@ -568,23 +560,19 @@ export class Ol {
 // Menu ...
 export class Menu {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Menu: string;
 }
 
 // Dir ...
 export class Dir {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dir: string;
 }
 
 // LIStyle is LIStyle is constrained to: "(ULStyle|OLStyle)"
-export enum LIStyle {
-	compact = 'compact',
-	compact = 'compact',
-	compact = 'compact',
-}
+export type LIStyle = string;
 
 // Li ...
 export class Li {
@@ -596,7 +584,7 @@ export class Li {
 // Dl ...
 export class Dl {
 	Attrs: Attrs;
-	CompactAttr: any | null;
+	CompactAttr: string | null;
 	Dt: Dt;
 	Dl: string;
 }
@@ -622,8 +610,8 @@ export class Address {
 // Hr ...
 export class Hr {
 	Attrs: Attrs;
-	AlignAttr: any | null;
-	NoshadeAttr: any | null;
+	AlignAttr: string | null;
+	NoshadeAttr: string | null;
 	SizeAttr: number | null;
 	WidthAttr: string | null;
 }
@@ -687,13 +675,13 @@ export class Bdo {
 	Events: Events;
 	LangAttr: string | null;
 	XmlLangAttr: Lang | null;
-	DirAttr: any;
+	DirAttr: string;
 }
 
 // Br ...
 export class Br {
 	Coreattrs: Coreattrs;
-	ClearAttr: any | null;
+	ClearAttr: string | null;
 }
 
 // Em ...
@@ -822,7 +810,7 @@ export class Font {
 // Object ...
 export class Object {
 	Attrs: Attrs;
-	DeclareAttr: any | null;
+	DeclareAttr: string | null;
 	ClassidAttr: string | null;
 	CodebaseAttr: string | null;
 	DataAttr: string | null;
@@ -851,7 +839,7 @@ export class Param {
 	IdAttr: string | null;
 	NameAttr: any;
 	ValueAttr: any | null;
-	ValuetypeAttr: any | null;
+	ValuetypeAttr: string | null;
 	TypeAttr: string | null;
 }
 
@@ -886,7 +874,7 @@ export class Img {
 	HeightAttr: string | null;
 	WidthAttr: string | null;
 	UsemapAttr: string | null;
-	IsmapAttr: any | null;
+	IsmapAttr: string | null;
 	AlignAttr: string | null;
 	BorderAttr: string | null;
 	HspaceAttr: number | null;
@@ -915,7 +903,7 @@ export class Area {
 	ShapeAttr: string | null;
 	CoordsAttr: string | null;
 	HrefAttr: string | null;
-	NohrefAttr: any | null;
+	NohrefAttr: string | null;
 	AltAttr: string;
 	TargetAttr: string | null;
 }
@@ -924,7 +912,7 @@ export class Area {
 export class Form {
 	Attrs: Attrs;
 	ActionAttr: string;
-	MethodAttr: any | null;
+	MethodAttr: string | null;
 	EnctypeAttr: string | null;
 	OnsubmitAttr: string | null;
 	OnresetAttr: string | null;
@@ -944,25 +932,6 @@ export class Label {
 
 // InputType ...
 export enum InputType {
-	compact = 'compact',
-	left = 'left',
-	center = 'center',
-	right = 'right',
-	noshade = 'noshade',
-	ltr = 'ltr',
-	rtl = 'rtl',
-	left = 'left',
-	all = 'all',
-	right = 'right',
-	none = 'none',
-	declare = 'declare',
-	data = 'data',
-	ref = 'ref',
-	object = 'object',
-	ismap = 'ismap',
-	nohref = 'nohref',
-	get = 'get',
-	post = 'post',
 	text = 'text',
 	password = 'password',
 	checkbox = 'checkbox',
@@ -982,9 +951,9 @@ export class Input {
 	TypeAttr: string | null;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	CheckedAttr: any | null;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	CheckedAttr: string | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	SizeAttr: any | null;
 	MaxlengthAttr: number | null;
 	SrcAttr: string | null;
@@ -1001,8 +970,8 @@ export class Select {
 	Attrs: Attrs;
 	NameAttr: any | null;
 	SizeAttr: number | null;
-	MultipleAttr: any | null;
-	DisabledAttr: any | null;
+	MultipleAttr: string | null;
+	DisabledAttr: string | null;
 	TabindexAttr: number | null;
 	OnfocusAttr: string | null;
 	OnblurAttr: string | null;
@@ -1014,7 +983,7 @@ export class Select {
 // Optgroup ...
 export class Optgroup {
 	Attrs: Attrs;
-	DisabledAttr: any | null;
+	DisabledAttr: string | null;
 	LabelAttr: string;
 	Optgroup: string;
 }
@@ -1022,8 +991,8 @@ export class Optgroup {
 // Option ...
 export class Option {
 	Attrs: Attrs;
-	SelectedAttr: any | null;
-	DisabledAttr: any | null;
+	SelectedAttr: string | null;
+	DisabledAttr: string | null;
 	LabelAttr: string | null;
 	ValueAttr: any | null;
 }
@@ -1035,8 +1004,8 @@ export class Textarea {
 	NameAttr: any | null;
 	RowsAttr: number;
 	ColsAttr: number;
-	DisabledAttr: any | null;
-	ReadonlyAttr: any | null;
+	DisabledAttr: string | null;
+	ReadonlyAttr: string | null;
 	OnselectAttr: string | null;
 	OnchangeAttr: string | null;
 }
@@ -1053,16 +1022,6 @@ export class Fieldset {
 
 // LAlign ...
 export enum LAlign {
-	checked = 'checked',
-	disabled = 'disabled',
-	readonly = 'readonly',
-	multiple = 'multiple',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	selected = 'selected',
-	disabled = 'disabled',
-	disabled = 'disabled',
-	readonly = 'readonly',
 	top = 'top',
 	bottom = 'bottom',
 	left = 'left',
@@ -1082,8 +1041,8 @@ export class Button {
 	Focus: Focus;
 	NameAttr: any | null;
 	ValueAttr: any | null;
-	TypeAttr: any | null;
-	DisabledAttr: any | null;
+	TypeAttr: string | null;
+	DisabledAttr: string | null;
 }
 
 // Isindex ...
@@ -1100,10 +1059,6 @@ export class Isindex {
 //       the table should be rendered. The values are not the same as
 //       CALS to avoid a name clash with the valign attribute.
 export enum TFrame {
-	button = 'button',
-	submit = 'submit',
-	reset = 'reset',
-	disabled = 'disabled',
 	void = 'void',
 	above = 'above',
 	below = 'below',
@@ -1256,7 +1211,7 @@ export class Th {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;
@@ -1273,7 +1228,7 @@ export class Td {
 	ScopeAttr: string | null;
 	RowspanAttr: number | null;
 	ColspanAttr: number | null;
-	NowrapAttr: any | null;
+	NowrapAttr: string | null;
 	BgcolorAttr: string | null;
 	WidthAttr: string | null;
 	HeightAttr: string | null;


### PR DESCRIPTION
This updates wrong expected outputs when types include attributes with enums. xgen used to have a bug which was fixed in https://github.com/xuri/xgen/pull/34. 

With those updates, the xgen tests are passing with the latest master version.